### PR TITLE
Refactor profile components with typed data and accessible nav

### DIFF
--- a/components/course-progress.tsx
+++ b/components/course-progress.tsx
@@ -3,38 +3,13 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Progress } from "@/components/ui/progress"
 import { Badge } from "@/components/ui/badge"
 import { BookOpen, Clock } from "lucide-react"
+import { Course, courses as defaultCourses } from "@/lib/data"
 
-export function CourseProgress() {
-  const courses = [
-    {
-      id: 1,
-      title: "Fundamentos de Finanzas",
-      progress: 75,
-      totalLessons: 12,
-      completedLessons: 9,
-      timeLeft: "2h 30min",
-      badge: "En progreso",
-    },
-    {
-      id: 2,
-      title: "Inversiones para Principiantes",
-      progress: 40,
-      totalLessons: 15,
-      completedLessons: 6,
-      timeLeft: "4h 15min",
-      badge: "En progreso",
-    },
-    {
-      id: 3,
-      title: "Presupuesto Personal",
-      progress: 100,
-      totalLessons: 8,
-      completedLessons: 8,
-      timeLeft: "Completado",
-      badge: "Completado",
-    },
-  ]
+interface CourseProgressProps {
+  courses?: Course[]
+}
 
+export function CourseProgress({ courses = defaultCourses }: CourseProgressProps) {
   return (
     <div className="space-y-4">
       {/* Overall Progress */}

--- a/components/posts-feed.tsx
+++ b/components/posts-feed.tsx
@@ -3,48 +3,14 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Heart, MessageCircle, Bookmark, Share } from "lucide-react"
+import { Post, posts as defaultPosts } from "@/lib/data"
 
 interface PostsFeedProps {
   showSocial?: boolean
+  posts?: Post[]
 }
 
-export function PostsFeed({ showSocial = false }: PostsFeedProps) {
-  const posts = [
-    {
-      id: 1,
-      user: "Santiago Carrasco",
-      username: "@santicarrasco",
-      time: "2h",
-      content: "Acabo de completar mi primera lección sobre presupuestos. ¡Me siento más confiado con mis finanzas!",
-      tags: ["#presupuesto", "#finanzas"],
-      likes: 12,
-      comments: 3,
-      avatar: "/diverse-user-avatars.png",
-    },
-    {
-      id: 2,
-      user: "Delfina Palmero",
-      username: "@delfinapalmero",
-      time: "4h",
-      content: "Compartiendo mi progreso del curso de inversiones. Ya voy por el 60% completado.",
-      tags: ["#inversiones", "#progreso"],
-      likes: 8,
-      comments: 1,
-      avatar: "/female-user-avatar.png",
-    },
-    {
-      id: 3,
-      user: "Juana Mora",
-      username: "@juanamora",
-      time: "6h",
-      content: "¿Alguien más está tomando el curso de criptomonedas? Me gustaría formar un grupo de estudio.",
-      tags: ["#crypto", "#estudio"],
-      likes: 15,
-      comments: 7,
-      avatar: "/professional-woman-avatar.png",
-    },
-  ]
-
+export function PostsFeed({ showSocial = false, posts = defaultPosts }: PostsFeedProps) {
   return (
     <div className="space-y-4">
       {posts.map((post) => (
@@ -91,10 +57,20 @@ export function PostsFeed({ showSocial = false }: PostsFeedProps) {
                 </Button>
               </div>
               <div className="flex items-center space-x-2">
-                <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-accent p-1">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground hover:text-accent p-1"
+                  aria-label="Guardar"
+                >
                   <Bookmark className="w-4 h-4" />
                 </Button>
-                <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-accent p-1">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground hover:text-accent p-1"
+                  aria-label="Compartir"
+                >
                   <Share className="w-4 h-4" />
                 </Button>
               </div>

--- a/components/profile-interface.tsx
+++ b/components/profile-interface.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
@@ -11,8 +12,16 @@ import { CourseProgress } from "./course-progress"
 import { SettingsPanel } from "./settings-panel"
 
 export function ProfileInterface() {
-  const [activeTab, setActiveTab] = useState("grid")
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const activeTab = searchParams.get("tab") ?? "grid"
   const [showSettings, setShowSettings] = useState(false)
+
+  const handleTabChange = (value: string) => {
+    const params = new URLSearchParams(searchParams)
+    params.set("tab", value)
+    router.replace(`?${params.toString()}`)
+  }
 
   if (showSettings) {
     return <SettingsPanel onBack={() => setShowSettings(false)} />
@@ -22,13 +31,14 @@ export function ProfileInterface() {
     <div className="max-w-md mx-auto bg-background min-h-screen">
       {/* Header */}
       <div className="bg-primary text-primary-foreground p-4 flex items-center justify-between">
-        <ChevronLeft className="w-6 h-6" />
+        <ChevronLeft className="w-6 h-6" aria-hidden="true" />
         <h1 className="font-bold text-lg">Tu Perfil</h1>
         <Button
           variant="ghost"
           size="icon"
           className="text-primary-foreground hover:bg-primary/20"
           onClick={() => setShowSettings(true)}
+          aria-label="Ajustes"
         >
           <Settings className="w-6 h-6" />
         </Button>
@@ -38,7 +48,7 @@ export function ProfileInterface() {
       <UserInfoCard />
 
       {/* Tab Navigation */}
-      <Tabs value={activeTab} onValueChange={setActiveTab} className="px-4">
+      <Tabs value={activeTab} onValueChange={handleTabChange} className="px-4">
         <TabsList className="grid w-full grid-cols-5 mb-4">
           <TabsTrigger value="grid" className="p-2">
             <Grid3X3 className="w-5 h-5" />
@@ -96,6 +106,7 @@ export function ProfileInterface() {
             variant="ghost"
             size="icon"
             className="text-primary-foreground/70 hover:text-primary-foreground hover:bg-primary/20"
+            aria-label="Tendencias"
           >
             <Flame className="w-6 h-6" />
           </Button>
@@ -103,6 +114,7 @@ export function ProfileInterface() {
             variant="ghost"
             size="icon"
             className="text-primary-foreground/70 hover:text-primary-foreground hover:bg-primary/20"
+            aria-label="Inicio"
           >
             <Home className="w-6 h-6" />
           </Button>
@@ -110,10 +122,16 @@ export function ProfileInterface() {
             variant="ghost"
             size="icon"
             className="text-primary-foreground/70 hover:text-primary-foreground hover:bg-primary/20"
+            aria-label="Explorar"
           >
             <Compass className="w-6 h-6" />
           </Button>
-          <Button variant="ghost" size="icon" className="text-primary-foreground hover:bg-primary/20">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-primary-foreground hover:bg-primary/20"
+            aria-label="Perfil"
+          >
             <User className="w-6 h-6" />
           </Button>
         </div>

--- a/components/settings-panel.tsx
+++ b/components/settings-panel.tsx
@@ -33,6 +33,7 @@ export function SettingsPanel({ onBack }: SettingsPanelProps) {
             size="icon"
             className="text-primary-foreground hover:bg-primary/20 mr-3"
             onClick={() => setShowPersonalData(false)}
+            aria-label="Volver"
           >
             <ChevronLeft className="w-6 h-6" />
           </Button>
@@ -127,6 +128,7 @@ export function SettingsPanel({ onBack }: SettingsPanelProps) {
           size="icon"
           className="text-primary-foreground hover:bg-primary/20 mr-3"
           onClick={onBack}
+          aria-label="Volver"
         >
           <ChevronLeft className="w-6 h-6" />
         </Button>

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,0 +1,87 @@
+export interface Post {
+  id: number;
+  user: string;
+  username: string;
+  time: string;
+  content: string;
+  tags: string[];
+  likes: number;
+  comments: number;
+  avatar: string;
+}
+
+export const posts: Post[] = [
+  {
+    id: 1,
+    user: "Santiago Carrasco",
+    username: "@santicarrasco",
+    time: "2h",
+    content: "Acabo de completar mi primera lección sobre presupuestos. ¡Me siento más confiado con mis finanzas!",
+    tags: ["#presupuesto", "#finanzas"],
+    likes: 12,
+    comments: 3,
+    avatar: "/diverse-user-avatars.png",
+  },
+  {
+    id: 2,
+    user: "Delfina Palmero",
+    username: "@delfinapalmero",
+    time: "4h",
+    content: "Compartiendo mi progreso del curso de inversiones. Ya voy por el 60% completado.",
+    tags: ["#inversiones", "#progreso"],
+    likes: 8,
+    comments: 1,
+    avatar: "/female-user-avatar.png",
+  },
+  {
+    id: 3,
+    user: "Juana Mora",
+    username: "@juanamora",
+    time: "6h",
+    content: "¿Alguien más está tomando el curso de criptomonedas? Me gustaría formar un grupo de estudio.",
+    tags: ["#crypto", "#estudio"],
+    likes: 15,
+    comments: 7,
+    avatar: "/professional-woman-avatar.png",
+  },
+];
+
+export interface Course {
+  id: number;
+  title: string;
+  progress: number;
+  totalLessons: number;
+  completedLessons: number;
+  timeLeft: string;
+  badge: string;
+}
+
+export const courses: Course[] = [
+  {
+    id: 1,
+    title: "Fundamentos de Finanzas",
+    progress: 75,
+    totalLessons: 12,
+    completedLessons: 9,
+    timeLeft: "2h 30min",
+    badge: "En progreso",
+  },
+  {
+    id: 2,
+    title: "Inversiones para Principiantes",
+    progress: 40,
+    totalLessons: 15,
+    completedLessons: 6,
+    timeLeft: "4h 15min",
+    badge: "En progreso",
+  },
+  {
+    id: 3,
+    title: "Presupuesto Personal",
+    progress: 100,
+    totalLessons: 8,
+    completedLessons: 8,
+    timeLeft: "Completado",
+    badge: "Completado",
+  },
+];


### PR DESCRIPTION
## Summary
- centralize Post and Course data into typed `lib/data` module
- enable deep-linked profile tabs using URL query params
- add `aria-label`s to icon-only buttons for better accessibility

## Testing
- `pnpm lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0df94797083218baf802c72a6743c