### PR TITLE
Refactor home and feed state management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+out
+dist
+build
+*.log
+.env

--- a/components/efin-feed.tsx
+++ b/components/efin-feed.tsx
@@ -1,111 +1,25 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useCallback } from "react"
 import { Card } from "./ui/card"
-import { Button } from "./ui/button"
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar"
 import { Badge } from "./ui/badge"
-import { Heart, MessageCircle, Repeat2, Bookmark, Play, TrendingUp } from "lucide-react"
+import { Play, TrendingUp } from "lucide-react"
 import { PopularLessons } from "./popular-lessons"
-
-interface FeedPost {
-  id: string
-  username: string
-  avatar: string
-  timestamp: string
-  content: string
-  likes: number
-  comments: number
-  reposts: number
-  isLiked: boolean
-  isSaved: boolean
-  isReposted: boolean
-  tags?: string[]
-  lessonReference?: {
-    title: string
-    progress: number
-  }
-}
+import { FeedTab } from "./feed-tabs"
+import { FeedPost, mockPosts } from "@/lib/posts"
+import { PostActions } from "./post-actions"
 
 interface EFINFeedProps {
-  activeTab: string
+  activeTab: FeedTab
 }
 
 export function EFINFeed({ activeTab }: EFINFeedProps) {
-  const [posts, setPosts] = useState<FeedPost[]>([
-    {
-      id: "1",
-      username: "FinanceGuru",
-      avatar: "/finance-expert.png",
-      timestamp: "2h",
-      content:
-        "Just completed the Time Value of Money module! The compound interest calculator really helped me understand how my investments will grow over time.",
-      likes: 24,
-      comments: 8,
-      reposts: 3,
-      isLiked: false,
-      isSaved: true,
-      isReposted: false,
-      tags: ["TimeValue", "CompoundInterest"],
-      lessonReference: {
-        title: "Time Value of Money",
-        progress: 100,
-      },
-    },
-    {
-      id: "2",
-      username: "InvestmentNewbie",
-      avatar: "/student-learning.png",
-      timestamp: "4h",
-      content:
-        "Can someone explain why money today is worth more than money tomorrow? Still wrapping my head around this concept.",
-      likes: 12,
-      comments: 15,
-      reposts: 1,
-      isLiked: true,
-      isSaved: false,
-      isReposted: false,
-      tags: ["Question", "TimeValue"],
-    },
-    {
-      id: "3",
-      username: "EFINTeacher",
-      avatar: "/teacher-professional.png",
-      timestamp: "6h",
-      content:
-        "Pro tip: Use the TVM simulator with different scenarios. Try calculating what happens if you save $100/month vs $200/month over 10 years. The difference will surprise you!",
-      likes: 45,
-      comments: 12,
-      reposts: 8,
-      isLiked: false,
-      isSaved: false,
-      isReposted: false,
-      tags: ["ProTip", "Savings", "TVM"],
-    },
-    {
-      id: "4",
-      username: "BudgetMaster",
-      avatar: "/budget-expert.png",
-      timestamp: "8h",
-      content:
-        "Started the budgeting fundamentals course today. The 50/30/20 rule is a game changer for managing expenses!",
-      likes: 18,
-      comments: 6,
-      reposts: 4,
-      isLiked: false,
-      isSaved: true,
-      isReposted: false,
-      tags: ["Budgeting", "PersonalFinance"],
-      lessonReference: {
-        title: "Budgeting Fundamentals",
-        progress: 25,
-      },
-    },
-  ])
+  const [posts, setPosts] = useState<FeedPost[]>(mockPosts)
 
-  const handleLike = (postId: string) => {
-    setPosts(
-      posts.map((post) =>
+  const handleLike = useCallback((postId: string) => {
+    setPosts((prev) =>
+      prev.map((post) =>
         post.id === postId
           ? {
               ...post,
@@ -115,15 +29,15 @@ export function EFINFeed({ activeTab }: EFINFeedProps) {
           : post,
       ),
     )
-  }
+  }, [])
 
-  const handleSave = (postId: string) => {
-    setPosts(posts.map((post) => (post.id === postId ? { ...post, isSaved: !post.isSaved } : post)))
-  }
+  const handleSave = useCallback((postId: string) => {
+    setPosts((prev) => prev.map((post) => (post.id === postId ? { ...post, isSaved: !post.isSaved } : post)))
+  }, [])
 
-  const handleRepost = (postId: string) => {
-    setPosts(
-      posts.map((post) =>
+  const handleRepost = useCallback((postId: string) => {
+    setPosts((prev) =>
+      prev.map((post) =>
         post.id === postId
           ? {
               ...post,
@@ -133,13 +47,13 @@ export function EFINFeed({ activeTab }: EFINFeedProps) {
           : post,
       ),
     )
-  }
+  }, [])
 
   const filteredPosts = posts.filter((post) => {
     switch (activeTab) {
-      case "Following":
+      case FeedTab.Following:
         return ["FinanceGuru", "EFINTeacher"].includes(post.username)
-      case "Finance":
+      case FeedTab.Finance:
         return post.tags?.some((tag) => ["TimeValue", "Budgeting", "PersonalFinance", "TVM"].includes(tag))
       default:
         return true
@@ -148,7 +62,7 @@ export function EFINFeed({ activeTab }: EFINFeedProps) {
 
   return (
     <div className="space-y-6">
-      {activeTab === "For You" && (
+      {activeTab === FeedTab.ForYou && (
         <div>
           <div className="flex items-center gap-2 mb-4">
             <TrendingUp className="h-5 w-5 text-efin-blue" />
@@ -198,51 +112,12 @@ export function EFINFeed({ activeTab }: EFINFeedProps) {
                 </div>
               )}
 
-              <div className="flex items-center justify-between">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => handleLike(post.id)}
-                  className={`flex items-center gap-2 transition-colors ${
-                    post.isLiked ? "text-red-500 hover:text-red-600" : "text-gray-500 hover:text-red-500"
-                  }`}
-                >
-                  <Heart className={`h-4 w-4 ${post.isLiked ? "fill-current" : ""}`} />
-                  {post.likes}
-                </Button>
-
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="flex items-center gap-2 text-gray-500 hover:text-efin-blue transition-colors"
-                >
-                  <MessageCircle className="h-4 w-4" />
-                  {post.comments}
-                </Button>
-
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => handleRepost(post.id)}
-                  className={`flex items-center gap-2 transition-colors ${
-                    post.isReposted ? "text-green-500 hover:text-green-600" : "text-gray-500 hover:text-green-500"
-                  }`}
-                >
-                  <Repeat2 className="h-4 w-4" />
-                  {post.reposts}
-                </Button>
-
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => handleSave(post.id)}
-                  className={`transition-colors ${
-                    post.isSaved ? "text-efin-blue hover:text-efin-blue/80" : "text-gray-500 hover:text-efin-blue"
-                  }`}
-                >
-                  <Bookmark className={`h-4 w-4 ${post.isSaved ? "fill-current" : ""}`} />
-                </Button>
-              </div>
+              <PostActions
+                post={post}
+                onLike={handleLike}
+                onRepost={handleRepost}
+                onSave={handleSave}
+              />
             </div>
           </div>
         </Card>

--- a/components/efin-home.tsx
+++ b/components/efin-home.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import { useState } from "react"
+import { useReducer } from "react"
 import { ContinueCourseCard } from "./continue-course-card"
-import { FeedTabs } from "./feed-tabs"
+import { FeedTabs, FeedTab } from "./feed-tabs"
 import { EFINFeed } from "./efin-feed"
 import { PostComposer } from "./post-composer"
 import { CourseModuleEngine } from "./course-module-engine"
@@ -10,17 +10,47 @@ import { UserProfile } from "./user-profile"
 import { Button } from "./ui/button"
 import { Plus, User } from "lucide-react"
 
-export function EFINHome() {
-  const [showPostComposer, setShowPostComposer] = useState(false)
-  const [showCourseModule, setShowCourseModule] = useState(false)
-  const [showProfile, setShowProfile] = useState(false)
-  const [activeTab, setActiveTab] = useState("For You")
+type HomeState = {
+  showPostComposer: boolean
+  showCourseModule: boolean
+  showProfile: boolean
+  activeTab: FeedTab
+}
 
-  if (showProfile) {
+type HomeAction =
+  | { type: "SHOW_POST_COMPOSER"; value: boolean }
+  | { type: "SHOW_COURSE_MODULE"; value: boolean }
+  | { type: "SHOW_PROFILE"; value: boolean }
+  | { type: "SET_ACTIVE_TAB"; value: FeedTab }
+
+function reducer(state: HomeState, action: HomeAction): HomeState {
+  switch (action.type) {
+    case "SHOW_POST_COMPOSER":
+      return { ...state, showPostComposer: action.value }
+    case "SHOW_COURSE_MODULE":
+      return { ...state, showCourseModule: action.value }
+    case "SHOW_PROFILE":
+      return { ...state, showProfile: action.value }
+    case "SET_ACTIVE_TAB":
+      return { ...state, activeTab: action.value }
+    default:
+      return state
+  }
+}
+
+export function EFINHome() {
+  const [state, dispatch] = useReducer(reducer, {
+    showPostComposer: false,
+    showCourseModule: false,
+    showProfile: false,
+    activeTab: FeedTab.ForYou,
+  })
+
+  if (state.showProfile) {
     return (
       <div>
         <div className="fixed top-4 left-4 z-10">
-          <Button onClick={() => setShowProfile(false)} variant="ghost" className="text-white hover:bg-white/10">
+          <Button onClick={() => dispatch({ type: "SHOW_PROFILE", value: false })} variant="ghost" className="text-white hover:bg-white/10">
             ← Back to Home
           </Button>
         </div>
@@ -35,10 +65,10 @@ export function EFINHome() {
       <div className="sticky top-0 z-10 bg-efin-light-gray pb-4">
         <div className="flex items-center justify-between p-4">
           <div className="flex-1">
-            <ContinueCourseCard onStartCourse={() => setShowCourseModule(true)} />
+            <ContinueCourseCard onStartCourse={() => dispatch({ type: "SHOW_COURSE_MODULE", value: true })} />
           </div>
           <Button
-            onClick={() => setShowProfile(true)}
+            onClick={() => dispatch({ type: "SHOW_PROFILE", value: true })}
             variant="ghost"
             size="icon"
             className="ml-4 text-efin-navy hover:bg-efin-navy/10"
@@ -49,16 +79,19 @@ export function EFINHome() {
       </div>
 
       {/* Navigation Tabs */}
-      <FeedTabs activeTab={activeTab} onTabChange={setActiveTab} />
+      <FeedTabs
+        activeTab={state.activeTab}
+        onTabChange={(tab) => dispatch({ type: "SET_ACTIVE_TAB", value: tab })}
+      />
 
       {/* Feed Content */}
       <div className="px-4 pb-20">
-        <EFINFeed activeTab={activeTab} />
+        <EFINFeed activeTab={state.activeTab} />
       </div>
 
       {/* Floating Action Button */}
       <Button
-        onClick={() => setShowPostComposer(true)}
+        onClick={() => dispatch({ type: "SHOW_POST_COMPOSER", value: true })}
         className="fixed bottom-6 right-6 h-14 w-14 rounded-full bg-efin-blue hover:bg-efin-blue/90 shadow-lg"
         size="icon"
       >
@@ -66,10 +99,14 @@ export function EFINHome() {
       </Button>
 
       {/* Post Composer Modal */}
-      {showPostComposer && <PostComposer onClose={() => setShowPostComposer(false)} />}
+      {state.showPostComposer && (
+        <PostComposer onClose={() => dispatch({ type: "SHOW_POST_COMPOSER", value: false })} />
+      )}
 
       {/* Course Module Engine */}
-      {showCourseModule && <CourseModuleEngine onClose={() => setShowCourseModule(false)} />}
+      {state.showCourseModule && (
+        <CourseModuleEngine onClose={() => dispatch({ type: "SHOW_COURSE_MODULE", value: false })} />
+      )}
     </div>
   )
 }

--- a/components/feed-tabs.tsx
+++ b/components/feed-tabs.tsx
@@ -2,13 +2,19 @@
 
 import { cn } from "@/lib/utils"
 
+export enum FeedTab {
+  ForYou = "For You",
+  Following = "Following",
+  Finance = "Finance",
+}
+
 interface FeedTabsProps {
-  activeTab: string
-  onTabChange: (tab: string) => void
+  activeTab: FeedTab
+  onTabChange: (tab: FeedTab) => void
 }
 
 export function FeedTabs({ activeTab, onTabChange }: FeedTabsProps) {
-  const tabs = ["For You", "Following", "Finance"]
+  const tabs = [FeedTab.ForYou, FeedTab.Following, FeedTab.Finance]
 
   return (
     <div className="px-4 mb-4">

--- a/components/post-actions.tsx
+++ b/components/post-actions.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { FeedPost } from "@/lib/posts"
+import { Button } from "./ui/button"
+import { Heart, MessageCircle, Repeat2, Bookmark } from "lucide-react"
+
+interface PostActionsProps {
+  post: FeedPost
+  onLike: (id: string) => void
+  onRepost: (id: string) => void
+  onSave: (id: string) => void
+}
+
+export function PostActions({ post, onLike, onRepost, onSave }: PostActionsProps) {
+  return (
+    <div className="flex items-center justify-between">
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => onLike(post.id)}
+        className={`flex items-center gap-2 transition-colors ${
+          post.isLiked ? "text-red-500 hover:text-red-600" : "text-gray-500 hover:text-red-500"
+        }`}
+      >
+        <Heart className={`h-4 w-4 ${post.isLiked ? "fill-current" : ""}`} />
+        {post.likes}
+      </Button>
+
+      <Button
+        variant="ghost"
+        size="sm"
+        className="flex items-center gap-2 text-gray-500 hover:text-efin-blue transition-colors"
+      >
+        <MessageCircle className="h-4 w-4" />
+        {post.comments}
+      </Button>
+
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => onRepost(post.id)}
+        className={`flex items-center gap-2 transition-colors ${
+          post.isReposted ? "text-green-500 hover:text-green-600" : "text-gray-500 hover:text-green-500"
+        }`}
+      >
+        <Repeat2 className="h-4 w-4" />
+        {post.reposts}
+      </Button>
+
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => onSave(post.id)}
+        className={`transition-colors ${
+          post.isSaved ? "text-efin-blue hover:text-efin-blue/80" : "text-gray-500 hover:text-efin-blue"
+        }`}
+      >
+        <Bookmark className={`h-4 w-4 ${post.isSaved ? "fill-current" : ""}`} />
+      </Button>
+    </div>
+  )
+}

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -1,0 +1,89 @@
+export interface FeedPost {
+  id: string
+  username: string
+  avatar: string
+  timestamp: string
+  content: string
+  likes: number
+  comments: number
+  reposts: number
+  isLiked: boolean
+  isSaved: boolean
+  isReposted: boolean
+  tags?: string[]
+  lessonReference?: {
+    title: string
+    progress: number
+  }
+}
+
+export const mockPosts: FeedPost[] = [
+  {
+    id: "1",
+    username: "FinanceGuru",
+    avatar: "/finance-expert.png",
+    timestamp: "2h",
+    content:
+      "Just completed the Time Value of Money module! The compound interest calculator really helped me understand how my investments will grow over time.",
+    likes: 24,
+    comments: 8,
+    reposts: 3,
+    isLiked: false,
+    isSaved: true,
+    isReposted: false,
+    tags: ["TimeValue", "CompoundInterest"],
+    lessonReference: {
+      title: "Time Value of Money",
+      progress: 100,
+    },
+  },
+  {
+    id: "2",
+    username: "InvestmentNewbie",
+    avatar: "/student-learning.png",
+    timestamp: "4h",
+    content:
+      "Can someone explain why money today is worth more than money tomorrow? Still wrapping my head around this concept.",
+    likes: 12,
+    comments: 15,
+    reposts: 1,
+    isLiked: true,
+    isSaved: false,
+    isReposted: false,
+    tags: ["Question", "TimeValue"],
+  },
+  {
+    id: "3",
+    username: "EFINTeacher",
+    avatar: "/teacher-professional.png",
+    timestamp: "6h",
+    content:
+      "Pro tip: Use the TVM simulator with different scenarios. Try calculating what happens if you save $100/month vs $200/month over 10 years. The difference will surprise you!",
+    likes: 45,
+    comments: 12,
+    reposts: 8,
+    isLiked: false,
+    isSaved: false,
+    isReposted: false,
+    tags: ["ProTip", "Savings", "TVM"],
+  },
+  {
+    id: "4",
+    username: "BudgetMaster",
+    avatar: "/budget-expert.png",
+    timestamp: "8h",
+    content:
+      "Started the budgeting fundamentals course today. The 50/30/20 rule is a game changer for managing expenses!",
+    likes: 18,
+    comments: 6,
+    reposts: 4,
+    isLiked: false,
+    isSaved: true,
+    isReposted: false,
+    tags: ["Budgeting", "PersonalFinance"],
+    lessonReference: {
+      title: "Budgeting Fundamentals",
+      progress: 25,
+    },
+  },
+]


### PR DESCRIPTION
## Summary
- centralize EFINHome state with a reducer
- move feed mock data to lib and reuse a PostActions component with memoized handlers
- type feed tabs with an enum and add project .gitignore

## Testing
- `pnpm lint` *(fails: Local package.json exists, but node_modules missing)*
- `pnpm install` *(fails: GET https://registry.npmjs.org/@types%2Freact: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d747e8988321838daafae372769c