### PR TITLE
Integrate onboarding flow with personalized home experience

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,51 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
 import { EFINHome } from "@/components/efin-home"
+import { EFINOnboarding, OnboardingData } from "@/components/efin-onboarding"
 
 export default function Page() {
-  return <EFINHome />
+  const [profile, setProfile] = useState<OnboardingData | null>(null)
+  const [isHydrated, setIsHydrated] = useState(false)
+
+  useEffect(() => {
+    const savedProfile = localStorage.getItem("efin-profile")
+    if (savedProfile) {
+      try {
+        const parsed = JSON.parse(savedProfile) as OnboardingData
+        setProfile(parsed)
+      } catch (error) {
+        console.error("Failed to parse saved profile", error)
+      }
+    }
+    setIsHydrated(true)
+  }, [])
+
+  const handleOnboardingComplete = (data: OnboardingData) => {
+    localStorage.setItem("efin-profile", JSON.stringify(data))
+    setProfile(data)
+  }
+
+  const handleResetProfile = () => {
+    localStorage.removeItem("efin-profile")
+    setProfile(null)
+  }
+
+  if (!isHydrated) {
+    return null
+  }
+
+  if (!profile) {
+    return <EFINOnboarding onComplete={handleOnboardingComplete} />
+  }
+
+  return (
+    <EFINHome
+      userName={profile.name}
+      objectives={profile.objectives}
+      interests={profile.interests}
+      onResetProfile={handleResetProfile}
+    />
+  )
 }

--- a/components/continue-course-card.tsx
+++ b/components/continue-course-card.tsx
@@ -7,17 +7,19 @@ import { Play, Settings } from "lucide-react"
 
 interface ContinueCourseCardProps {
   onStartCourse?: () => void
+  userName?: string
 }
 
-export function ContinueCourseCard({ onStartCourse }: ContinueCourseCardProps) {
+export function ContinueCourseCard({ onStartCourse, userName }: ContinueCourseCardProps) {
   const progress = 65 // Current progress percentage
+  const displayName = userName ?? "Santiago Carrasco"
 
   return (
     <div className="p-4">
       <Card className="bg-efin-navy text-white p-6 rounded-2xl shadow-xl">
         <div className="flex items-start justify-between mb-4">
           <div>
-            <h2 className="text-xl font-semibold mb-1">Santiago Carrasco</h2>
+            <h2 className="text-xl font-semibold mb-1">{displayName}</h2>
             <p className="text-efin-turquoise text-sm font-medium">Continue Class - IN PROGRESS</p>
           </div>
           <Button variant="ghost" size="icon" className="text-white hover:bg-white/10">

--- a/components/efin-home.tsx
+++ b/components/efin-home.tsx
@@ -23,6 +23,13 @@ type HomeAction =
   | { type: "SHOW_PROFILE"; value: boolean }
   | { type: "SET_ACTIVE_TAB"; value: FeedTab }
 
+interface EFINHomeProps {
+  userName?: string
+  objectives?: string[]
+  interests?: string[]
+  onResetProfile?: () => void
+}
+
 function reducer(state: HomeState, action: HomeAction): HomeState {
   switch (action.type) {
     case "SHOW_POST_COMPOSER":
@@ -38,7 +45,7 @@ function reducer(state: HomeState, action: HomeAction): HomeState {
   }
 }
 
-export function EFINHome() {
+export function EFINHome({ userName, objectives, interests, onResetProfile }: EFINHomeProps) {
   const [state, dispatch] = useReducer(reducer, {
     showPostComposer: false,
     showCourseModule: false,
@@ -54,7 +61,12 @@ export function EFINHome() {
             ← Back to Home
           </Button>
         </div>
-        <UserProfile />
+        <UserProfile
+          name={userName}
+          objectives={objectives}
+          interests={interests}
+          onResetProfile={onResetProfile}
+        />
       </div>
     )
   }
@@ -65,7 +77,10 @@ export function EFINHome() {
       <div className="sticky top-0 z-10 bg-efin-light-gray pb-4">
         <div className="flex items-center justify-between p-4">
           <div className="flex-1">
-            <ContinueCourseCard onStartCourse={() => dispatch({ type: "SHOW_COURSE_MODULE", value: true })} />
+            <ContinueCourseCard
+              userName={userName}
+              onStartCourse={() => dispatch({ type: "SHOW_COURSE_MODULE", value: true })}
+            />
           </div>
           <Button
             onClick={() => dispatch({ type: "SHOW_PROFILE", value: true })}
@@ -86,7 +101,7 @@ export function EFINHome() {
 
       {/* Feed Content */}
       <div className="px-4 pb-20">
-        <EFINFeed activeTab={state.activeTab} />
+        <EFINFeed activeTab={state.activeTab} interests={interests} />
       </div>
 
       {/* Floating Action Button */}

--- a/components/efin-onboarding.tsx
+++ b/components/efin-onboarding.tsx
@@ -1,0 +1,357 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { ArrowLeft, Apple, CheckCircle2, Mail, Sparkles, UserRound } from "lucide-react"
+
+import { Button } from "./ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card"
+import { Checkbox } from "./ui/checkbox"
+import { Input } from "./ui/input"
+import { Label } from "./ui/label"
+import { Progress } from "./ui/progress"
+
+export type OnboardingStep =
+  | "registration"
+  | "age"
+  | "objective"
+  | "learning"
+  | "interests"
+  | "success"
+
+export interface OnboardingData {
+  name: string
+  email: string
+  age: number
+  objectives: string[]
+  learningPreferences: string[]
+  interests: string[]
+}
+
+interface EFINOnboardingProps {
+  onComplete: (data: OnboardingData) => void
+}
+
+const learningObjectives = [
+  "Mejorar mis finanzas personales",
+  "Prepararme para inversiones",
+  "Entender créditos y préstamos",
+  "Aprender a presupuestar",
+]
+
+const learningModes = [
+  "Lecciones interactivas",
+  "Videos cortos",
+  "Casos prácticos",
+  "Simuladores financieros",
+]
+
+const interestAreas = [
+  "Inversiones",
+  "Presupuesto",
+  "Finanzas personales",
+  "Cripto & Web3",
+  "Economía",
+  "Mercados",
+]
+
+export function EFINOnboarding({ onComplete }: EFINOnboardingProps) {
+  const steps: OnboardingStep[] = useMemo(
+    () => ["registration", "age", "objective", "learning", "interests", "success"],
+    [],
+  )
+
+  const [currentStep, setCurrentStep] = useState<OnboardingStep>("registration")
+  const [formData, setFormData] = useState<OnboardingData>({
+    name: "",
+    email: "",
+    age: 18,
+    objectives: [],
+    learningPreferences: [],
+    interests: [],
+  })
+
+  const currentStepIndex = steps.indexOf(currentStep)
+  const progress = ((currentStepIndex + 1) / steps.length) * 100
+
+  const goToStep = (direction: 1 | -1) => {
+    const newIndex = currentStepIndex + direction
+    if (newIndex >= 0 && newIndex < steps.length) {
+      setCurrentStep(steps[newIndex])
+    }
+  }
+
+  const toggleValue = (key: keyof Pick<OnboardingData, "objectives" | "learningPreferences" | "interests">, value: string) => {
+    setFormData((prev) => {
+      const current = prev[key]
+      const exists = current.includes(value)
+
+      return {
+        ...prev,
+        [key]: exists ? current.filter((item) => item !== value) : [...current, value],
+      }
+    })
+  }
+
+  const renderHeader = (title: string, description: string) => (
+    <CardHeader className="text-center">
+      <CardTitle className="text-2xl font-semibold text-foreground">{title}</CardTitle>
+      <CardDescription className="text-base text-muted-foreground">{description}</CardDescription>
+    </CardHeader>
+  )
+
+  const renderBackButton = currentStep !== "registration" ? (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => goToStep(-1)}
+      className="absolute left-4 top-4 text-muted-foreground hover:text-foreground"
+    >
+      <ArrowLeft className="h-5 w-5" />
+    </Button>
+  ) : null
+
+  const actionButtonText =
+    currentStep === "success"
+      ? "Ir al inicio"
+      : currentStepIndex === steps.length - 2
+        ? "Finalizar"
+        : "Continuar"
+
+  const handleComplete = () => {
+    const result: OnboardingData = {
+      name: formData.name.trim() || "Invitado",
+      email: formData.email.trim(),
+      age: formData.age,
+      objectives: formData.objectives,
+      learningPreferences: formData.learningPreferences,
+      interests: formData.interests,
+    }
+
+    localStorage.setItem("efin-profile", JSON.stringify(result))
+    onComplete(result)
+  }
+
+  const RegistrationStep = (
+    <>
+      {renderHeader("Bienvenido a EFIN", "Creamos un plan personalizado para tu aprendizaje financiero")}
+      <CardContent className="space-y-6 pb-8">
+        <div className="grid grid-cols-3 gap-3">
+          <Button variant="outline" className="flex items-center justify-center gap-2">
+            <Mail className="h-4 w-4" />
+            <span className="text-xs font-medium">Email</span>
+          </Button>
+          <Button variant="outline" className="flex items-center justify-center gap-2">
+            <Apple className="h-4 w-4" />
+            <span className="text-xs font-medium">Apple</span>
+          </Button>
+          <Button variant="outline" className="flex items-center justify-center gap-2">
+            <UserRound className="h-4 w-4" />
+            <span className="text-xs font-medium">Continuar</span>
+          </Button>
+        </div>
+
+        <div className="space-y-4">
+          <div className="space-y-2 text-left">
+            <Label htmlFor="name">Nombre completo</Label>
+            <Input
+              id="name"
+              placeholder="Ingresa tu nombre"
+              value={formData.name}
+              onChange={(event) => setFormData((prev) => ({ ...prev, name: event.target.value }))}
+            />
+          </div>
+          <div className="space-y-2 text-left">
+            <Label htmlFor="email">Correo electrónico</Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="tucorreo@ejemplo.com"
+              value={formData.email}
+              onChange={(event) => setFormData((prev) => ({ ...prev, email: event.target.value }))}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2 text-left">
+              <Label htmlFor="password">Contraseña</Label>
+              <Input id="password" type="password" placeholder="••••••" />
+            </div>
+            <div className="space-y-2 text-left">
+              <Label htmlFor="password-confirm">Confirmar contraseña</Label>
+              <Input id="password-confirm" type="password" placeholder="••••••" />
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </>
+  )
+
+  const AgeStep = (
+    <>
+      {renderHeader("¿Cuál es tu edad?", "Adaptamos el contenido a tu etapa de aprendizaje")}
+      <CardContent className="space-y-6 pb-8">
+        <div className="flex justify-center">
+          <div className="rounded-2xl bg-primary/10 p-8 text-center">
+            <p className="text-sm text-muted-foreground">Tu edad</p>
+            <Input
+              type="number"
+              min={14}
+              max={100}
+              className="mt-3 w-24 text-center text-xl"
+              value={formData.age}
+              onChange={(event) => {
+                const parsedValue = Number.parseInt(event.target.value, 10)
+                setFormData((prev) => ({
+                  ...prev,
+                  age: Number.isNaN(parsedValue) ? 18 : parsedValue,
+                }))
+              }}
+            />
+          </div>
+        </div>
+        <p className="text-center text-sm text-muted-foreground">
+          Utilizamos esta información para recomendar cursos y contenidos adecuados.
+        </p>
+      </CardContent>
+    </>
+  )
+
+  const ObjectiveStep = (
+    <>
+      {renderHeader("¿Cuál es tu objetivo principal?", "Selecciona todas las opciones que se ajusten a tus metas")}
+      <CardContent className="space-y-4 pb-8">
+        {learningObjectives.map((item) => (
+          <Label
+            key={item}
+            className="flex cursor-pointer items-center justify-between rounded-xl border bg-card/60 p-4 hover:border-primary"
+          >
+            <span className="text-sm font-medium text-foreground">{item}</span>
+            <Checkbox
+              checked={formData.objectives.includes(item)}
+              onCheckedChange={() => toggleValue("objectives", item)}
+            />
+          </Label>
+        ))}
+      </CardContent>
+    </>
+  )
+
+  const LearningStep = (
+    <>
+      {renderHeader("¿Cómo prefieres aprender?", "Personalizamos el formato de tus clases y recursos")}
+      <CardContent className="space-y-4 pb-8">
+        {learningModes.map((item) => (
+          <Label
+            key={item}
+            className="flex cursor-pointer items-center justify-between rounded-xl border bg-card/60 p-4 hover:border-primary"
+          >
+            <span className="text-sm font-medium text-foreground">{item}</span>
+            <Checkbox
+              checked={formData.learningPreferences.includes(item)}
+              onCheckedChange={() => toggleValue("learningPreferences", item)}
+            />
+          </Label>
+        ))}
+      </CardContent>
+    </>
+  )
+
+  const InterestsStep = (
+    <>
+      {renderHeader("¿Qué temas te interesan?", "Creamos un feed con contenido relevante para ti")}
+      <CardContent className="grid grid-cols-2 gap-3 pb-8 sm:grid-cols-3">
+        {interestAreas.map((item) => (
+          <Label
+            key={item}
+            className={`flex cursor-pointer items-center justify-between rounded-xl border p-3 text-sm font-medium transition-colors ${
+              formData.interests.includes(item)
+                ? "border-primary bg-primary/10 text-primary"
+                : "border-border bg-card/60 text-foreground"
+            }`}
+          >
+            {item}
+            <Checkbox
+              checked={formData.interests.includes(item)}
+              onCheckedChange={() => toggleValue("interests", item)}
+            />
+          </Label>
+        ))}
+      </CardContent>
+    </>
+  )
+
+  const SuccessStep = (
+    <>
+      {renderHeader("¡Listo para comenzar!", "Construimos tu experiencia personalizada en finanzas")}
+      <CardContent className="space-y-6 pb-10 text-center">
+        <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <CheckCircle2 className="h-8 w-8" />
+        </div>
+        <div className="space-y-2">
+          <p className="text-lg font-semibold text-foreground">Bienvenido, {formData.name || "Invitado"}</p>
+          <p className="text-sm text-muted-foreground">
+            Comienza explorando tu feed personalizado y continúa con tus cursos recomendados.
+          </p>
+        </div>
+        <div className="rounded-2xl bg-muted/30 p-4 text-left">
+          <p className="text-sm font-semibold text-muted-foreground">Tus intereses principales</p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {(formData.interests.length ? formData.interests : interestAreas.slice(0, 3)).map((item) => (
+              <span
+                key={item}
+                className="rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary"
+              >
+                {item}
+              </span>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </>
+  )
+
+  const stepContent: Record<OnboardingStep, JSX.Element> = {
+    registration: RegistrationStep,
+    age: AgeStep,
+    objective: ObjectiveStep,
+    learning: LearningStep,
+    interests: InterestsStep,
+    success: SuccessStep,
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-efin-navy/5 p-4">
+      <div className="w-full max-w-2xl">
+        <div className="relative">
+          {renderBackButton}
+          <Card className="overflow-hidden border-none bg-white shadow-2xl">
+            <div className="relative">
+              <div className="absolute right-6 top-6 inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+                <Sparkles className="h-4 w-4" />
+                Paso {currentStepIndex + 1} de {steps.length}
+              </div>
+              <Progress value={progress} className="h-1 w-full bg-muted" />
+            </div>
+            {stepContent[currentStep]}
+            <CardContent className="flex justify-between gap-3 border-t pt-6">
+              <div>
+                <p className="text-xs text-muted-foreground">
+                  Guardamos tu progreso para personalizar tu experiencia.
+                </p>
+              </div>
+              <Button
+                className="min-w-[120px] bg-primary text-primary-foreground hover:bg-primary/90"
+                onClick={
+                  currentStep === "success"
+                    ? handleComplete
+                    : () => goToStep(1)
+                }
+              >
+                {actionButtonText}
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/user-profile.tsx
+++ b/components/user-profile.tsx
@@ -3,10 +3,28 @@
 import { Card } from "./ui/card"
 import { Button } from "./ui/button"
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar"
+import { Badge } from "./ui/badge"
 import { UserBadges } from "./user-badges"
 import { User, Settings, BookOpen } from "lucide-react"
 
-export function UserProfile() {
+interface UserProfileProps {
+  name?: string
+  objectives?: string[]
+  interests?: string[]
+  onResetProfile?: () => void
+}
+
+export function UserProfile({ name, objectives = [], interests = [], onResetProfile }: UserProfileProps) {
+  const displayName = name ?? "Santiago Carrasco"
+  const initials = displayName
+    .split(" ")
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase())
+    .join("")
+    .slice(0, 2) || "SC"
+  const displayedObjectives = objectives.length > 0 ? objectives : ["Explorar finanzas personales"]
+  const displayedInterests = interests.length > 0 ? interests : ["Inversiones", "Presupuesto"]
+
   return (
     <div className="min-h-screen bg-efin-navy p-4">
       <div className="max-w-2xl mx-auto space-y-6">
@@ -14,11 +32,11 @@ export function UserProfile() {
         <Card className="p-6 bg-white/10 backdrop-blur-sm border-white/20">
           <div className="flex items-center gap-4 mb-4">
             <Avatar className="h-16 w-16">
-              <AvatarImage src="/placeholder.svg" alt="Santiago Carrasco" />
-              <AvatarFallback className="bg-efin-blue text-white text-lg">SC</AvatarFallback>
+              <AvatarImage src="/placeholder.svg" alt={displayName} />
+              <AvatarFallback className="bg-efin-blue text-white text-lg">{initials}</AvatarFallback>
             </Avatar>
             <div className="flex-1">
-              <h1 className="text-xl font-bold text-white">Santiago Carrasco</h1>
+              <h1 className="text-xl font-bold text-white">{displayName}</h1>
               <p className="text-efin-turquoise text-sm">Finance Learning Journey</p>
             </div>
             <Button variant="ghost" size="icon" className="text-white hover:bg-white/10">
@@ -41,6 +59,30 @@ export function UserProfile() {
         {/* Badges Section */}
         <UserBadges />
 
+        {/* Objectives */}
+        <Card className="p-6 bg-white/10 backdrop-blur-sm border-white/20">
+          <h3 className="text-lg font-semibold text-white mb-4">Metas de aprendizaje</h3>
+          <div className="flex flex-wrap gap-2">
+            {displayedObjectives.map((objective) => (
+              <Badge key={objective} variant="outline" className="border-efin-turquoise/40 text-efin-turquoise">
+                {objective}
+              </Badge>
+            ))}
+          </div>
+        </Card>
+
+        {/* Interests */}
+        <Card className="p-6 bg-white/10 backdrop-blur-sm border-white/20">
+          <h3 className="text-lg font-semibold text-white mb-4">Temas de interés</h3>
+          <div className="flex flex-wrap gap-2">
+            {displayedInterests.map((interest) => (
+              <Badge key={interest} className="bg-efin-blue/20 text-efin-turquoise">
+                {interest}
+              </Badge>
+            ))}
+          </div>
+        </Card>
+
         {/* Quick Actions */}
         <Card className="p-6 bg-white/10 backdrop-blur-sm border-white/20">
           <h3 className="text-lg font-semibold text-white mb-4">Quick Actions</h3>
@@ -56,6 +98,16 @@ export function UserProfile() {
               <User className="h-4 w-4 mr-2" />
               View Learning Path
             </Button>
+            {onResetProfile && (
+              <Button
+                variant="ghost"
+                onClick={onResetProfile}
+                className="w-full justify-start text-efin-turquoise hover:bg-efin-turquoise/10"
+              >
+                <Settings className="h-4 w-4 mr-2" />
+                Actualizar preferencias
+              </Button>
+            )}
           </div>
         </Card>
       </div>

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- add a multi-step EFIN onboarding flow that captures user goals and interests and persists them in localStorage
- route the main page through onboarding before rendering the home experience and allow resetting stored preferences
- personalize the home, feed, and profile components with onboarding data including user name, interests, and learning objectives

## Testing
- pnpm lint *(fails: prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cab07e4bf08321a0a050ccf3e2b82d