### PR TITLE
Add Fintok short-video feed to home experience

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,51 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
 import { EFINHome } from "@/components/efin-home"
+import { EFINOnboarding, OnboardingData } from "@/components/efin-onboarding"
 
 export default function Page() {
-  return <EFINHome />
+  const [profile, setProfile] = useState<OnboardingData | null>(null)
+  const [isHydrated, setIsHydrated] = useState(false)
+
+  useEffect(() => {
+    const savedProfile = localStorage.getItem("efin-profile")
+    if (savedProfile) {
+      try {
+        const parsed = JSON.parse(savedProfile) as OnboardingData
+        setProfile(parsed)
+      } catch (error) {
+        console.error("Failed to parse saved profile", error)
+      }
+    }
+    setIsHydrated(true)
+  }, [])
+
+  const handleOnboardingComplete = (data: OnboardingData) => {
+    localStorage.setItem("efin-profile", JSON.stringify(data))
+    setProfile(data)
+  }
+
+  const handleResetProfile = () => {
+    localStorage.removeItem("efin-profile")
+    setProfile(null)
+  }
+
+  if (!isHydrated) {
+    return null
+  }
+
+  if (!profile) {
+    return <EFINOnboarding onComplete={handleOnboardingComplete} />
+  }
+
+  return (
+    <EFINHome
+      userName={profile.name}
+      objectives={profile.objectives}
+      interests={profile.interests}
+      onResetProfile={handleResetProfile}
+    />
+  )
 }

--- a/components/continue-course-card.tsx
+++ b/components/continue-course-card.tsx
@@ -7,17 +7,19 @@ import { Play, Settings } from "lucide-react"
 
 interface ContinueCourseCardProps {
   onStartCourse?: () => void
+  userName?: string
 }
 
-export function ContinueCourseCard({ onStartCourse }: ContinueCourseCardProps) {
+export function ContinueCourseCard({ onStartCourse, userName }: ContinueCourseCardProps) {
   const progress = 65 // Current progress percentage
+  const displayName = userName ?? "Santiago Carrasco"
 
   return (
     <div className="p-4">
       <Card className="bg-efin-navy text-white p-6 rounded-2xl shadow-xl">
         <div className="flex items-start justify-between mb-4">
           <div>
-            <h2 className="text-xl font-semibold mb-1">Santiago Carrasco</h2>
+            <h2 className="text-xl font-semibold mb-1">{displayName}</h2>
             <p className="text-efin-turquoise text-sm font-medium">Continue Class - IN PROGRESS</p>
           </div>
           <Button variant="ghost" size="icon" className="text-white hover:bg-white/10">

--- a/components/efin-home.tsx
+++ b/components/efin-home.tsx
@@ -11,19 +11,15 @@ import { Button } from "./ui/button"
 import { FintokFeed } from "./fintok-feed"
 import { Flame, Home as HomeIcon, Plus, User } from "lucide-react"
 
+type HomeOverlay = "none" | "postComposer" | "courseModule" | "profile" | "fintok"
+
 type HomeState = {
-  showPostComposer: boolean
-  showCourseModule: boolean
-  showProfile: boolean
-  showFintok: boolean
+  activeOverlay: HomeOverlay
   activeTab: FeedTab
 }
 
 type HomeAction =
-  | { type: "SHOW_POST_COMPOSER"; value: boolean }
-  | { type: "SHOW_COURSE_MODULE"; value: boolean }
-  | { type: "SHOW_PROFILE"; value: boolean }
-  | { type: "SHOW_FINTOK"; value: boolean }
+  | { type: "SET_OVERLAY"; value: HomeOverlay }
   | { type: "SET_ACTIVE_TAB"; value: FeedTab }
 
 interface EFINHomeProps {
@@ -35,14 +31,8 @@ interface EFINHomeProps {
 
 function reducer(state: HomeState, action: HomeAction): HomeState {
   switch (action.type) {
-    case "SHOW_POST_COMPOSER":
-      return { ...state, showPostComposer: action.value }
-    case "SHOW_COURSE_MODULE":
-      return { ...state, showCourseModule: action.value }
-    case "SHOW_PROFILE":
-      return { ...state, showProfile: action.value }
-    case "SHOW_FINTOK":
-      return { ...state, showFintok: action.value }
+    case "SET_OVERLAY":
+      return { ...state, activeOverlay: action.value }
     case "SET_ACTIVE_TAB":
       return { ...state, activeTab: action.value }
     default:
@@ -51,28 +41,30 @@ function reducer(state: HomeState, action: HomeAction): HomeState {
 }
 
 export function EFINHome({ userName, objectives, interests, onResetProfile }: EFINHomeProps) {
-  const [state, dispatch] = useReducer(reducer, {
-    showPostComposer: false,
-    showCourseModule: false,
-    showProfile: false,
-    showFintok: false,
+  const initialState: HomeState = {
+    activeOverlay: "none",
     activeTab: FeedTab.ForYou,
-  })
+  }
+  const [state, dispatch] = useReducer(reducer, initialState)
 
-  if (state.showFintok) {
+  if (state.activeOverlay === "fintok") {
     return (
       <FintokFeed
         interests={interests}
-        onClose={() => dispatch({ type: "SHOW_FINTOK", value: false })}
+        onClose={() => dispatch({ type: "SET_OVERLAY", value: "none" })}
       />
     )
   }
 
-  if (state.showProfile) {
+  if (state.activeOverlay === "profile") {
     return (
       <div>
         <div className="fixed top-4 left-4 z-10">
-          <Button onClick={() => dispatch({ type: "SHOW_PROFILE", value: false })} variant="ghost" className="text-white hover:bg-white/10">
+          <Button
+            onClick={() => dispatch({ type: "SET_OVERLAY", value: "none" })}
+            variant="ghost"
+            className="text-white hover:bg-white/10"
+          >
             ← Back to Home
           </Button>
         </div>
@@ -94,11 +86,11 @@ export function EFINHome({ userName, objectives, interests, onResetProfile }: EF
           <div className="flex-1">
             <ContinueCourseCard
               userName={userName}
-              onStartCourse={() => dispatch({ type: "SHOW_COURSE_MODULE", value: true })}
+              onStartCourse={() => dispatch({ type: "SET_OVERLAY", value: "courseModule" })}
             />
           </div>
           <Button
-            onClick={() => dispatch({ type: "SHOW_PROFILE", value: true })}
+            onClick={() => dispatch({ type: "SET_OVERLAY", value: "profile" })}
             variant="ghost"
             size="icon"
             className="ml-4 text-efin-navy hover:bg-efin-navy/10"
@@ -121,9 +113,7 @@ export function EFINHome({ userName, objectives, interests, onResetProfile }: EF
 
       <div className="fixed bottom-6 left-1/2 z-20 flex -translate-x-1/2 items-center gap-3 rounded-full bg-white/80 px-4 py-2 text-efin-navy shadow-lg backdrop-blur">
         <Button
-          onClick={() => {
-            dispatch({ type: "SHOW_FINTOK", value: false })
-          }}
+          onClick={() => dispatch({ type: "SET_OVERLAY", value: "none" })}
           variant="ghost"
           size="icon"
           className="h-10 w-10 rounded-full text-efin-navy hover:bg-efin-navy/10"
@@ -132,18 +122,27 @@ export function EFINHome({ userName, objectives, interests, onResetProfile }: EF
           <HomeIcon className="h-5 w-5" />
         </Button>
         <Button
-          onClick={() => dispatch({ type: "SHOW_FINTOK", value: true })}
+          onClick={() => dispatch({ type: "SET_OVERLAY", value: "fintok" })}
           size="icon"
           className="h-10 w-10 rounded-full bg-gradient-to-br from-orange-400 to-pink-500 text-white shadow-md hover:from-orange-500 hover:to-pink-500"
           aria-label="Abrir Fintok"
         >
           <Flame className="h-5 w-5" />
         </Button>
+        <Button
+          onClick={() => dispatch({ type: "SET_OVERLAY", value: "profile" })}
+          variant="ghost"
+          size="icon"
+          className="h-10 w-10 rounded-full text-efin-navy hover:bg-efin-navy/10"
+          aria-label="Perfil"
+        >
+          <User className="h-5 w-5" />
+        </Button>
       </div>
 
       {/* Floating Action Button */}
       <Button
-        onClick={() => dispatch({ type: "SHOW_POST_COMPOSER", value: true })}
+        onClick={() => dispatch({ type: "SET_OVERLAY", value: "postComposer" })}
         className="fixed bottom-6 right-6 h-14 w-14 rounded-full bg-efin-blue hover:bg-efin-blue/90 shadow-lg"
         size="icon"
       >
@@ -151,13 +150,13 @@ export function EFINHome({ userName, objectives, interests, onResetProfile }: EF
       </Button>
 
       {/* Post Composer Modal */}
-      {state.showPostComposer && (
-        <PostComposer onClose={() => dispatch({ type: "SHOW_POST_COMPOSER", value: false })} />
+      {state.activeOverlay === "postComposer" && (
+        <PostComposer onClose={() => dispatch({ type: "SET_OVERLAY", value: "none" })} />
       )}
 
       {/* Course Module Engine */}
-      {state.showCourseModule && (
-        <CourseModuleEngine onClose={() => dispatch({ type: "SHOW_COURSE_MODULE", value: false })} />
+      {state.activeOverlay === "courseModule" && (
+        <CourseModuleEngine onClose={() => dispatch({ type: "SET_OVERLAY", value: "none" })} />
       )}
     </div>
   )

--- a/components/efin-home.tsx
+++ b/components/efin-home.tsx
@@ -8,12 +8,14 @@ import { PostComposer } from "./post-composer"
 import { CourseModuleEngine } from "./course-module-engine"
 import { UserProfile } from "./user-profile"
 import { Button } from "./ui/button"
-import { Plus, User } from "lucide-react"
+import { FintokFeed } from "./fintok-feed"
+import { Flame, Home as HomeIcon, Plus, User } from "lucide-react"
 
 type HomeState = {
   showPostComposer: boolean
   showCourseModule: boolean
   showProfile: boolean
+  showFintok: boolean
   activeTab: FeedTab
 }
 
@@ -21,7 +23,15 @@ type HomeAction =
   | { type: "SHOW_POST_COMPOSER"; value: boolean }
   | { type: "SHOW_COURSE_MODULE"; value: boolean }
   | { type: "SHOW_PROFILE"; value: boolean }
+  | { type: "SHOW_FINTOK"; value: boolean }
   | { type: "SET_ACTIVE_TAB"; value: FeedTab }
+
+interface EFINHomeProps {
+  userName?: string
+  objectives?: string[]
+  interests?: string[]
+  onResetProfile?: () => void
+}
 
 function reducer(state: HomeState, action: HomeAction): HomeState {
   switch (action.type) {
@@ -31,6 +41,8 @@ function reducer(state: HomeState, action: HomeAction): HomeState {
       return { ...state, showCourseModule: action.value }
     case "SHOW_PROFILE":
       return { ...state, showProfile: action.value }
+    case "SHOW_FINTOK":
+      return { ...state, showFintok: action.value }
     case "SET_ACTIVE_TAB":
       return { ...state, activeTab: action.value }
     default:
@@ -38,13 +50,23 @@ function reducer(state: HomeState, action: HomeAction): HomeState {
   }
 }
 
-export function EFINHome() {
+export function EFINHome({ userName, objectives, interests, onResetProfile }: EFINHomeProps) {
   const [state, dispatch] = useReducer(reducer, {
     showPostComposer: false,
     showCourseModule: false,
     showProfile: false,
+    showFintok: false,
     activeTab: FeedTab.ForYou,
   })
+
+  if (state.showFintok) {
+    return (
+      <FintokFeed
+        interests={interests}
+        onClose={() => dispatch({ type: "SHOW_FINTOK", value: false })}
+      />
+    )
+  }
 
   if (state.showProfile) {
     return (
@@ -54,7 +76,12 @@ export function EFINHome() {
             ← Back to Home
           </Button>
         </div>
-        <UserProfile />
+        <UserProfile
+          name={userName}
+          objectives={objectives}
+          interests={interests}
+          onResetProfile={onResetProfile}
+        />
       </div>
     )
   }
@@ -65,7 +92,10 @@ export function EFINHome() {
       <div className="sticky top-0 z-10 bg-efin-light-gray pb-4">
         <div className="flex items-center justify-between p-4">
           <div className="flex-1">
-            <ContinueCourseCard onStartCourse={() => dispatch({ type: "SHOW_COURSE_MODULE", value: true })} />
+            <ContinueCourseCard
+              userName={userName}
+              onStartCourse={() => dispatch({ type: "SHOW_COURSE_MODULE", value: true })}
+            />
           </div>
           <Button
             onClick={() => dispatch({ type: "SHOW_PROFILE", value: true })}
@@ -86,7 +116,29 @@ export function EFINHome() {
 
       {/* Feed Content */}
       <div className="px-4 pb-20">
-        <EFINFeed activeTab={state.activeTab} />
+        <EFINFeed activeTab={state.activeTab} interests={interests} />
+      </div>
+
+      <div className="fixed bottom-6 left-1/2 z-20 flex -translate-x-1/2 items-center gap-3 rounded-full bg-white/80 px-4 py-2 text-efin-navy shadow-lg backdrop-blur">
+        <Button
+          onClick={() => {
+            dispatch({ type: "SHOW_FINTOK", value: false })
+          }}
+          variant="ghost"
+          size="icon"
+          className="h-10 w-10 rounded-full text-efin-navy hover:bg-efin-navy/10"
+          aria-label="Inicio"
+        >
+          <HomeIcon className="h-5 w-5" />
+        </Button>
+        <Button
+          onClick={() => dispatch({ type: "SHOW_FINTOK", value: true })}
+          size="icon"
+          className="h-10 w-10 rounded-full bg-gradient-to-br from-orange-400 to-pink-500 text-white shadow-md hover:from-orange-500 hover:to-pink-500"
+          aria-label="Abrir Fintok"
+        >
+          <Flame className="h-5 w-5" />
+        </Button>
       </div>
 
       {/* Floating Action Button */}

--- a/components/efin-onboarding.tsx
+++ b/components/efin-onboarding.tsx
@@ -1,0 +1,357 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { ArrowLeft, Apple, CheckCircle2, Mail, Sparkles, UserRound } from "lucide-react"
+
+import { Button } from "./ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "./ui/card"
+import { Checkbox } from "./ui/checkbox"
+import { Input } from "./ui/input"
+import { Label } from "./ui/label"
+import { Progress } from "./ui/progress"
+
+export type OnboardingStep =
+  | "registration"
+  | "age"
+  | "objective"
+  | "learning"
+  | "interests"
+  | "success"
+
+export interface OnboardingData {
+  name: string
+  email: string
+  age: number
+  objectives: string[]
+  learningPreferences: string[]
+  interests: string[]
+}
+
+interface EFINOnboardingProps {
+  onComplete: (data: OnboardingData) => void
+}
+
+const learningObjectives = [
+  "Mejorar mis finanzas personales",
+  "Prepararme para inversiones",
+  "Entender créditos y préstamos",
+  "Aprender a presupuestar",
+]
+
+const learningModes = [
+  "Lecciones interactivas",
+  "Videos cortos",
+  "Casos prácticos",
+  "Simuladores financieros",
+]
+
+const interestAreas = [
+  "Inversiones",
+  "Presupuesto",
+  "Finanzas personales",
+  "Cripto & Web3",
+  "Economía",
+  "Mercados",
+]
+
+export function EFINOnboarding({ onComplete }: EFINOnboardingProps) {
+  const steps: OnboardingStep[] = useMemo(
+    () => ["registration", "age", "objective", "learning", "interests", "success"],
+    [],
+  )
+
+  const [currentStep, setCurrentStep] = useState<OnboardingStep>("registration")
+  const [formData, setFormData] = useState<OnboardingData>({
+    name: "",
+    email: "",
+    age: 18,
+    objectives: [],
+    learningPreferences: [],
+    interests: [],
+  })
+
+  const currentStepIndex = steps.indexOf(currentStep)
+  const progress = ((currentStepIndex + 1) / steps.length) * 100
+
+  const goToStep = (direction: 1 | -1) => {
+    const newIndex = currentStepIndex + direction
+    if (newIndex >= 0 && newIndex < steps.length) {
+      setCurrentStep(steps[newIndex])
+    }
+  }
+
+  const toggleValue = (key: keyof Pick<OnboardingData, "objectives" | "learningPreferences" | "interests">, value: string) => {
+    setFormData((prev) => {
+      const current = prev[key]
+      const exists = current.includes(value)
+
+      return {
+        ...prev,
+        [key]: exists ? current.filter((item) => item !== value) : [...current, value],
+      }
+    })
+  }
+
+  const renderHeader = (title: string, description: string) => (
+    <CardHeader className="text-center">
+      <CardTitle className="text-2xl font-semibold text-foreground">{title}</CardTitle>
+      <CardDescription className="text-base text-muted-foreground">{description}</CardDescription>
+    </CardHeader>
+  )
+
+  const renderBackButton = currentStep !== "registration" ? (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => goToStep(-1)}
+      className="absolute left-4 top-4 text-muted-foreground hover:text-foreground"
+    >
+      <ArrowLeft className="h-5 w-5" />
+    </Button>
+  ) : null
+
+  const actionButtonText =
+    currentStep === "success"
+      ? "Ir al inicio"
+      : currentStepIndex === steps.length - 2
+        ? "Finalizar"
+        : "Continuar"
+
+  const handleComplete = () => {
+    const result: OnboardingData = {
+      name: formData.name.trim() || "Invitado",
+      email: formData.email.trim(),
+      age: formData.age,
+      objectives: formData.objectives,
+      learningPreferences: formData.learningPreferences,
+      interests: formData.interests,
+    }
+
+    localStorage.setItem("efin-profile", JSON.stringify(result))
+    onComplete(result)
+  }
+
+  const RegistrationStep = (
+    <>
+      {renderHeader("Bienvenido a EFIN", "Creamos un plan personalizado para tu aprendizaje financiero")}
+      <CardContent className="space-y-6 pb-8">
+        <div className="grid grid-cols-3 gap-3">
+          <Button variant="outline" className="flex items-center justify-center gap-2">
+            <Mail className="h-4 w-4" />
+            <span className="text-xs font-medium">Email</span>
+          </Button>
+          <Button variant="outline" className="flex items-center justify-center gap-2">
+            <Apple className="h-4 w-4" />
+            <span className="text-xs font-medium">Apple</span>
+          </Button>
+          <Button variant="outline" className="flex items-center justify-center gap-2">
+            <UserRound className="h-4 w-4" />
+            <span className="text-xs font-medium">Continuar</span>
+          </Button>
+        </div>
+
+        <div className="space-y-4">
+          <div className="space-y-2 text-left">
+            <Label htmlFor="name">Nombre completo</Label>
+            <Input
+              id="name"
+              placeholder="Ingresa tu nombre"
+              value={formData.name}
+              onChange={(event) => setFormData((prev) => ({ ...prev, name: event.target.value }))}
+            />
+          </div>
+          <div className="space-y-2 text-left">
+            <Label htmlFor="email">Correo electrónico</Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="tucorreo@ejemplo.com"
+              value={formData.email}
+              onChange={(event) => setFormData((prev) => ({ ...prev, email: event.target.value }))}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2 text-left">
+              <Label htmlFor="password">Contraseña</Label>
+              <Input id="password" type="password" placeholder="••••••" />
+            </div>
+            <div className="space-y-2 text-left">
+              <Label htmlFor="password-confirm">Confirmar contraseña</Label>
+              <Input id="password-confirm" type="password" placeholder="••••••" />
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </>
+  )
+
+  const AgeStep = (
+    <>
+      {renderHeader("¿Cuál es tu edad?", "Adaptamos el contenido a tu etapa de aprendizaje")}
+      <CardContent className="space-y-6 pb-8">
+        <div className="flex justify-center">
+          <div className="rounded-2xl bg-primary/10 p-8 text-center">
+            <p className="text-sm text-muted-foreground">Tu edad</p>
+            <Input
+              type="number"
+              min={14}
+              max={100}
+              className="mt-3 w-24 text-center text-xl"
+              value={formData.age}
+              onChange={(event) => {
+                const parsedValue = Number.parseInt(event.target.value, 10)
+                setFormData((prev) => ({
+                  ...prev,
+                  age: Number.isNaN(parsedValue) ? 18 : parsedValue,
+                }))
+              }}
+            />
+          </div>
+        </div>
+        <p className="text-center text-sm text-muted-foreground">
+          Utilizamos esta información para recomendar cursos y contenidos adecuados.
+        </p>
+      </CardContent>
+    </>
+  )
+
+  const ObjectiveStep = (
+    <>
+      {renderHeader("¿Cuál es tu objetivo principal?", "Selecciona todas las opciones que se ajusten a tus metas")}
+      <CardContent className="space-y-4 pb-8">
+        {learningObjectives.map((item) => (
+          <Label
+            key={item}
+            className="flex cursor-pointer items-center justify-between rounded-xl border bg-card/60 p-4 hover:border-primary"
+          >
+            <span className="text-sm font-medium text-foreground">{item}</span>
+            <Checkbox
+              checked={formData.objectives.includes(item)}
+              onCheckedChange={() => toggleValue("objectives", item)}
+            />
+          </Label>
+        ))}
+      </CardContent>
+    </>
+  )
+
+  const LearningStep = (
+    <>
+      {renderHeader("¿Cómo prefieres aprender?", "Personalizamos el formato de tus clases y recursos")}
+      <CardContent className="space-y-4 pb-8">
+        {learningModes.map((item) => (
+          <Label
+            key={item}
+            className="flex cursor-pointer items-center justify-between rounded-xl border bg-card/60 p-4 hover:border-primary"
+          >
+            <span className="text-sm font-medium text-foreground">{item}</span>
+            <Checkbox
+              checked={formData.learningPreferences.includes(item)}
+              onCheckedChange={() => toggleValue("learningPreferences", item)}
+            />
+          </Label>
+        ))}
+      </CardContent>
+    </>
+  )
+
+  const InterestsStep = (
+    <>
+      {renderHeader("¿Qué temas te interesan?", "Creamos un feed con contenido relevante para ti")}
+      <CardContent className="grid grid-cols-2 gap-3 pb-8 sm:grid-cols-3">
+        {interestAreas.map((item) => (
+          <Label
+            key={item}
+            className={`flex cursor-pointer items-center justify-between rounded-xl border p-3 text-sm font-medium transition-colors ${
+              formData.interests.includes(item)
+                ? "border-primary bg-primary/10 text-primary"
+                : "border-border bg-card/60 text-foreground"
+            }`}
+          >
+            {item}
+            <Checkbox
+              checked={formData.interests.includes(item)}
+              onCheckedChange={() => toggleValue("interests", item)}
+            />
+          </Label>
+        ))}
+      </CardContent>
+    </>
+  )
+
+  const SuccessStep = (
+    <>
+      {renderHeader("¡Listo para comenzar!", "Construimos tu experiencia personalizada en finanzas")}
+      <CardContent className="space-y-6 pb-10 text-center">
+        <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <CheckCircle2 className="h-8 w-8" />
+        </div>
+        <div className="space-y-2">
+          <p className="text-lg font-semibold text-foreground">Bienvenido, {formData.name || "Invitado"}</p>
+          <p className="text-sm text-muted-foreground">
+            Comienza explorando tu feed personalizado y continúa con tus cursos recomendados.
+          </p>
+        </div>
+        <div className="rounded-2xl bg-muted/30 p-4 text-left">
+          <p className="text-sm font-semibold text-muted-foreground">Tus intereses principales</p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {(formData.interests.length ? formData.interests : interestAreas.slice(0, 3)).map((item) => (
+              <span
+                key={item}
+                className="rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary"
+              >
+                {item}
+              </span>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </>
+  )
+
+  const stepContent: Record<OnboardingStep, JSX.Element> = {
+    registration: RegistrationStep,
+    age: AgeStep,
+    objective: ObjectiveStep,
+    learning: LearningStep,
+    interests: InterestsStep,
+    success: SuccessStep,
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-efin-navy/5 p-4">
+      <div className="w-full max-w-2xl">
+        <div className="relative">
+          {renderBackButton}
+          <Card className="overflow-hidden border-none bg-white shadow-2xl">
+            <div className="relative">
+              <div className="absolute right-6 top-6 inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+                <Sparkles className="h-4 w-4" />
+                Paso {currentStepIndex + 1} de {steps.length}
+              </div>
+              <Progress value={progress} className="h-1 w-full bg-muted" />
+            </div>
+            {stepContent[currentStep]}
+            <CardContent className="flex justify-between gap-3 border-t pt-6">
+              <div>
+                <p className="text-xs text-muted-foreground">
+                  Guardamos tu progreso para personalizar tu experiencia.
+                </p>
+              </div>
+              <Button
+                className="min-w-[120px] bg-primary text-primary-foreground hover:bg-primary/90"
+                onClick={
+                  currentStep === "success"
+                    ? handleComplete
+                    : () => goToStep(1)
+                }
+              >
+                {actionButtonText}
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/fintok-feed.tsx
+++ b/components/fintok-feed.tsx
@@ -1,0 +1,165 @@
+"use client"
+
+import Image from "next/image"
+import { useEffect, useMemo, useRef, useState } from "react"
+import { Flame, Heart, MessageCircle, Share2, Volume2, VolumeX, X } from "lucide-react"
+
+import { fintokClips } from "@/lib/fintok"
+import { Button } from "./ui/button"
+
+interface FintokFeedProps {
+  onClose: () => void
+  interests?: string[]
+}
+
+export function FintokFeed({ onClose, interests }: FintokFeedProps) {
+  const videoRefs = useRef<(HTMLVideoElement | null)[]>([])
+  const [isMuted, setIsMuted] = useState(true)
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          const video = entry.target as HTMLVideoElement
+          if (entry.isIntersecting) {
+            const playPromise = video.play()
+            if (playPromise !== undefined) {
+              playPromise.catch(() => null)
+            }
+          } else {
+            video.pause()
+            video.currentTime = 0
+          }
+        })
+      },
+      { threshold: 0.75 },
+    )
+
+    videoRefs.current.forEach((video) => {
+      if (video) {
+        observer.observe(video)
+      }
+    })
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [])
+
+  useEffect(() => {
+    videoRefs.current.forEach((video) => {
+      if (video) {
+        video.muted = isMuted
+      }
+    })
+  }, [isMuted])
+
+  const interestHint = useMemo(() => {
+    if (!interests?.length) {
+      return null
+    }
+
+    const topSelections = interests.slice(0, 2).join(", ")
+    return `Curado para tus intereses: ${topSelections}`
+  }, [interests])
+
+  return (
+    <div className="fixed inset-0 z-40 bg-black text-white">
+      <div className="absolute inset-x-0 top-0 flex items-center justify-between px-4 py-4">
+        <div className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-white/70">
+          <Flame className="h-5 w-5 text-orange-500" />
+          <span>Fintok</span>
+        </div>
+        <div className="flex items-center gap-3">
+          {interestHint && (
+            <span className="hidden rounded-full bg-white/10 px-3 py-1 text-xs font-medium text-white/80 sm:block">
+              {interestHint}
+            </span>
+          )}
+          <Button
+            onClick={onClose}
+            variant="ghost"
+            size="icon"
+            className="h-9 w-9 rounded-full border border-white/20 bg-black/40 text-white hover:bg-white/10"
+            aria-label="Volver al inicio"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="absolute inset-x-0 top-14 flex items-center justify-between px-4 text-xs text-white/60">
+        <span>Deslizá hacia arriba para más videos</span>
+        <button
+          onClick={() => setIsMuted((prev) => !prev)}
+          className="flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 font-medium hover:bg-white/20"
+          aria-label={isMuted ? "Activar sonido" : "Silenciar"}
+        >
+          {isMuted ? <VolumeX className="h-4 w-4" /> : <Volume2 className="h-4 w-4" />}
+          <span>{isMuted ? "Sonido off" : "Sonido on"}</span>
+        </button>
+      </div>
+
+      <div className="h-full w-full overflow-y-auto snap-y snap-mandatory">
+        {fintokClips.map((clip, index) => (
+          <section key={clip.id} className="relative flex h-screen w-full snap-start items-end justify-between pb-20">
+            <video
+              ref={(element) => {
+                videoRefs.current[index] = element
+              }}
+              src={clip.videoUrl}
+              className="absolute inset-0 h-full w-full object-cover"
+              playsInline
+              loop
+              muted={isMuted}
+              preload="metadata"
+            />
+
+            <div className="absolute inset-0 bg-gradient-to-t from-black via-black/20 to-transparent" />
+
+            <div className="relative z-10 w-full px-6 pb-6 pr-24">
+              <div className="mb-4 flex items-center gap-3">
+                <div className="relative h-12 w-12 overflow-hidden rounded-full border-2 border-white/40">
+                  <Image src={clip.avatar} alt={clip.creator} fill sizes="48px" className="object-cover" />
+                </div>
+                <div>
+                  <p className="text-sm font-semibold">{clip.creator}</p>
+                  <p className="text-xs text-white/70">{clip.role}</p>
+                </div>
+              </div>
+
+              <h2 className="text-lg font-semibold leading-tight">{clip.title}</h2>
+              <p className="mt-2 text-sm text-white/80">{clip.description}</p>
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                {clip.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-full bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white/70"
+                  >
+                    #{tag}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            <aside className="absolute bottom-28 right-4 z-10 flex flex-col items-center gap-6 text-sm font-medium">
+              <button className="flex h-12 w-12 flex-col items-center justify-center gap-1 rounded-full bg-white/10 text-white hover:bg-white/20">
+                <Heart className="h-5 w-5" />
+                <span className="text-xs">{clip.likes.toLocaleString()}</span>
+              </button>
+              <button className="flex h-12 w-12 flex-col items-center justify-center gap-1 rounded-full bg-white/10 text-white hover:bg-white/20">
+                <MessageCircle className="h-5 w-5" />
+                <span className="text-xs">{clip.comments.toLocaleString()}</span>
+              </button>
+              <button className="flex h-12 w-12 flex-col items-center justify-center gap-1 rounded-full bg-white/10 text-white hover:bg-white/20">
+                <Share2 className="h-5 w-5" />
+                <span className="text-xs">{clip.shares.toLocaleString()}</span>
+              </button>
+            </aside>
+          </section>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/user-profile.tsx
+++ b/components/user-profile.tsx
@@ -3,10 +3,28 @@
 import { Card } from "./ui/card"
 import { Button } from "./ui/button"
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar"
+import { Badge } from "./ui/badge"
 import { UserBadges } from "./user-badges"
 import { User, Settings, BookOpen } from "lucide-react"
 
-export function UserProfile() {
+interface UserProfileProps {
+  name?: string
+  objectives?: string[]
+  interests?: string[]
+  onResetProfile?: () => void
+}
+
+export function UserProfile({ name, objectives = [], interests = [], onResetProfile }: UserProfileProps) {
+  const displayName = name ?? "Santiago Carrasco"
+  const initials = displayName
+    .split(" ")
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase())
+    .join("")
+    .slice(0, 2) || "SC"
+  const displayedObjectives = objectives.length > 0 ? objectives : ["Explorar finanzas personales"]
+  const displayedInterests = interests.length > 0 ? interests : ["Inversiones", "Presupuesto"]
+
   return (
     <div className="min-h-screen bg-efin-navy p-4">
       <div className="max-w-2xl mx-auto space-y-6">
@@ -14,11 +32,11 @@ export function UserProfile() {
         <Card className="p-6 bg-white/10 backdrop-blur-sm border-white/20">
           <div className="flex items-center gap-4 mb-4">
             <Avatar className="h-16 w-16">
-              <AvatarImage src="/placeholder.svg" alt="Santiago Carrasco" />
-              <AvatarFallback className="bg-efin-blue text-white text-lg">SC</AvatarFallback>
+              <AvatarImage src="/placeholder.svg" alt={displayName} />
+              <AvatarFallback className="bg-efin-blue text-white text-lg">{initials}</AvatarFallback>
             </Avatar>
             <div className="flex-1">
-              <h1 className="text-xl font-bold text-white">Santiago Carrasco</h1>
+              <h1 className="text-xl font-bold text-white">{displayName}</h1>
               <p className="text-efin-turquoise text-sm">Finance Learning Journey</p>
             </div>
             <Button variant="ghost" size="icon" className="text-white hover:bg-white/10">
@@ -41,6 +59,30 @@ export function UserProfile() {
         {/* Badges Section */}
         <UserBadges />
 
+        {/* Objectives */}
+        <Card className="p-6 bg-white/10 backdrop-blur-sm border-white/20">
+          <h3 className="text-lg font-semibold text-white mb-4">Metas de aprendizaje</h3>
+          <div className="flex flex-wrap gap-2">
+            {displayedObjectives.map((objective) => (
+              <Badge key={objective} variant="outline" className="border-efin-turquoise/40 text-efin-turquoise">
+                {objective}
+              </Badge>
+            ))}
+          </div>
+        </Card>
+
+        {/* Interests */}
+        <Card className="p-6 bg-white/10 backdrop-blur-sm border-white/20">
+          <h3 className="text-lg font-semibold text-white mb-4">Temas de interés</h3>
+          <div className="flex flex-wrap gap-2">
+            {displayedInterests.map((interest) => (
+              <Badge key={interest} className="bg-efin-blue/20 text-efin-turquoise">
+                {interest}
+              </Badge>
+            ))}
+          </div>
+        </Card>
+
         {/* Quick Actions */}
         <Card className="p-6 bg-white/10 backdrop-blur-sm border-white/20">
           <h3 className="text-lg font-semibold text-white mb-4">Quick Actions</h3>
@@ -56,6 +98,16 @@ export function UserProfile() {
               <User className="h-4 w-4 mr-2" />
               View Learning Path
             </Button>
+            {onResetProfile && (
+              <Button
+                variant="ghost"
+                onClick={onResetProfile}
+                className="w-full justify-start text-efin-turquoise hover:bg-efin-turquoise/10"
+              >
+                <Settings className="h-4 w-4 mr-2" />
+                Actualizar preferencias
+              </Button>
+            )}
           </div>
         </Card>
       </div>

--- a/lib/fintok.ts
+++ b/lib/fintok.ts
@@ -1,0 +1,72 @@
+export interface FintokClip {
+  id: string
+  title: string
+  description: string
+  creator: string
+  role: string
+  avatar: string
+  videoUrl: string
+  likes: number
+  comments: number
+  shares: number
+  tags: string[]
+}
+
+export const fintokClips: FintokClip[] = [
+  {
+    id: "clip-1",
+    title: "¿Qué es el interés compuesto?",
+    description:
+      "Imagina que tu dinero trabaja por ti todos los días. Así es como el interés compuesto acelera tu ahorro.",
+    creator: "Sofi Inversiones",
+    role: "Educadora financiera",
+    avatar: "/finance-expert.png",
+    videoUrl: "https://storage.googleapis.com/coverr-main/mp4/Mt_Baker.mp4",
+    likes: 1280,
+    comments: 86,
+    shares: 42,
+    tags: ["InteresCompuesto", "Ahorro", "FinanzasPersonales"],
+  },
+  {
+    id: "clip-2",
+    title: "Gasto hormiga vs. presupuesto",
+    description:
+      "Un truco rápido para detectar tus gastos invisibles y redirigirlos a tus objetivos de inversión.",
+    creator: "Lucas Advisor",
+    role: "Coach financiero",
+    avatar: "/student-learning.png",
+    videoUrl: "https://storage.googleapis.com/coverr-main/mp4/Sailing.mp4",
+    likes: 940,
+    comments: 64,
+    shares: 33,
+    tags: ["Budgeting", "GastoHormiga", "Tips"],
+  },
+  {
+    id: "clip-3",
+    title: "Cripto en 60 segundos",
+    description:
+      "Tres conceptos clave antes de comprar tu primera criptomoneda. No olvides tu fondo de emergencia.",
+    creator: "CryptoVale",
+    role: "Analista",
+    avatar: "/teacher-professional.png",
+    videoUrl: "https://storage.googleapis.com/coverr-main/mp4/Mt_Baker_Sunset.mp4",
+    likes: 1575,
+    comments: 132,
+    shares: 71,
+    tags: ["Cripto", "Inversiones", "Riesgo"],
+  },
+  {
+    id: "clip-4",
+    title: "Simulá tus metas",
+    description:
+      "Usá nuestro simulador para proyectar cuánto necesitás ahorrar cada mes y alcanzar tus objetivos.",
+    creator: "Equipo EFIN",
+    role: "Producto",
+    avatar: "/placeholder-user.jpg",
+    videoUrl: "https://storage.googleapis.com/coverr-main/mp4/Footboys.mp4",
+    likes: 680,
+    comments: 41,
+    shares: 18,
+    tags: ["Metas", "Simulador", "Planificacion"],
+  },
+]

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- add a floating navigation pill that opens the new Fintok experience from the flame shortcut on the home screen
- implement a vertical, auto-playing financial video feed that can be dismissed to return home and honours stored interests in its messaging
- seed curated mock Fintok clips with metadata and streaming sources to populate the short-video feed

## Testing
- pnpm lint *(fails: command prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cab07e4bf08321a0a050ccf3e2b82d